### PR TITLE
fix: use otsu's method for default threshold

### DIFF
--- a/internal/ascii_art/ascii_art.go
+++ b/internal/ascii_art/ascii_art.go
@@ -16,7 +16,7 @@ func selectRandomly(chars string) string {
 	return string(chars[r])
 }
 
-// Generate generates an ASCII art from an image.
+// `Generate` generates an ASCII art from an image.
 func Generate(dest image.Image, threshold int) string {
 	srcBounds := dest.Bounds()
 

--- a/internal/ascii_art/ascii_art.go
+++ b/internal/ascii_art/ascii_art.go
@@ -3,6 +3,7 @@ package asciiart
 import (
 	"image"
 	"image/color"
+	"math"
 	"math/rand"
 	"strings"
 )
@@ -10,11 +11,6 @@ import (
 const (
 	validChars = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 )
-
-func selectRandomly(chars string) string {
-	r := rand.Intn(len(chars))
-	return string(chars[r])
-}
 
 // `Generate` generates an ASCII art from an image.
 func Generate(dest image.Image, threshold int) string {
@@ -43,4 +39,58 @@ func Generate(dest image.Image, threshold int) string {
 	}
 
 	return asciiArt.String()
+}
+
+func selectRandomly(chars string) string {
+	r := rand.Intn(len(chars))
+	return string(chars[r])
+}
+
+// `CalcOTSUThreshold` calculates the threshold value using the OTSU's method.
+func CalcOTSUThreshold(dest image.Image, ySize, xSize int) int {
+	histogram := make([]int, 256) // 0 - 255 histogram
+
+	for y := 0; y < ySize; y++ {
+		for x := 0; x < xSize; x++ {
+			c := color.GrayModel.Convert(dest.At(x, y))
+			gray, _ := c.(color.Gray)
+			histogram[gray.Y]++
+		}
+	}
+
+	t := 0
+	max := 0.0
+
+	for i := 0; i < 256; i++ {
+		w1, w2 := 0, 0     // pixel number
+		sum1, sum2 := 0, 0 // total gray value
+		m1, m2 := 0.0, 0.0 // average gray value
+
+		for j := 0; j < i; j++ {
+			w1 += histogram[j]
+			sum1 += histogram[j] * j
+		}
+
+		for j := i; j < 256; j++ {
+			w2 += histogram[j]
+			sum2 += j * histogram[j]
+		}
+
+		if 0 < w1 {
+			m1 = float64(sum1) / float64(w1)
+		}
+
+		if 0 < w2 {
+			m2 = float64(sum2) / float64(w2)
+		}
+
+		tmp := float64(w1) * float64(w2) * math.Pow(m1-m2, 2)
+
+		if max < tmp {
+			max = tmp
+			t = i
+		}
+	}
+
+	return t
 }

--- a/internal/img/img.go
+++ b/internal/img/img.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/image/draw"
 )
 
-// Load loads an image from a file.
+// `Load` loads an image from a file.
 func Load(path string) (image.Image, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -25,7 +25,7 @@ func Load(path string) (image.Image, error) {
 	return img, nil
 }
 
-// Resize resizes an image to a given width and height.
+// `Resize` resizes an image to a given width and height.
 func Resize(img image.Image, magnification float64) *image.RGBA {
 	rect := img.Bounds()
 
@@ -48,7 +48,7 @@ func Resize(img image.Image, magnification float64) *image.RGBA {
 	return dest
 }
 
-// UnSync unsynchronizes an image file.
+// `UnSync` unsynchronizes an image file.
 func UnSync(dest image.Image) error {
 	tmp, err := os.Create("tmp.png")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	DefaultThreshold     = 128
+	DefaultMagnification = 1.0
+)
+
 type Inputs struct {
 	path          string
 	threshold     int
@@ -25,14 +30,14 @@ func main() {
 				Name:        "threshold",
 				Aliases:     []string{"t"},
 				Usage:       "the threshold for ASCII Art Generation",
-				Value:       128,
+				Value:       DefaultThreshold,
 				Destination: &inputs.threshold,
 			},
 			&cli.Float64Flag{
 				Name:        "magnification",
 				Aliases:     []string{"m"},
 				Usage:       "the magnification factor for ASCII Art Generation",
-				Value:       1.0,
+				Value:       DefaultMagnification,
 				Destination: &inputs.magnification,
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	DefaultThreshold     = 128
 	DefaultMagnification = 1.0
 )
 
@@ -22,33 +21,24 @@ type Inputs struct {
 }
 
 func main() {
-	inputs := Inputs{}
-
 	app := &cli.App{
 		Flags: []cli.Flag{
 			&cli.IntFlag{
-				Name:        "threshold",
-				Aliases:     []string{"t"},
-				Usage:       "the threshold for ASCII Art Generation",
-				Value:       DefaultThreshold,
-				Destination: &inputs.threshold,
+				Name:    "threshold",
+				Aliases: []string{"t"},
+				Usage:   "the threshold for ASCII Art Generation",
 			},
 			&cli.Float64Flag{
-				Name:        "magnification",
-				Aliases:     []string{"m"},
-				Usage:       "the magnification factor for ASCII Art Generation",
-				Value:       DefaultMagnification,
-				Destination: &inputs.magnification,
+				Name:    "magnification",
+				Aliases: []string{"m"},
+				Usage:   "the magnification factor for ASCII Art Generation",
 			},
 		},
 		Action: func(c *cli.Context) error {
-			if c.NArg() != 1 {
-				return fmt.Errorf("invalid number of arguments")
+			err := runApp(c)
+			if err != nil {
+				return err
 			}
-			inputs.path = c.Args().Get(0)
-
-			run(&inputs)
-
 			return nil
 		},
 	}
@@ -58,20 +48,44 @@ func main() {
 	}
 }
 
-func run(inputs *Inputs) {
+func runApp(c *cli.Context) error {
+	inputs := Inputs{}
+	if c.NArg() != 1 {
+		return fmt.Errorf("invalid number of arguments")
+	}
+	inputs.path = c.Args().Get(0)
+
+	// Load the image
 	srcImg, err := img.Load(inputs.path)
 	if err != nil {
-		log.Fatalf("Error: %v", err)
+		return err
 	}
 
+	if c.IsSet("magnification") {
+		inputs.magnification = c.Float64("magnification")
+	} else {
+		inputs.magnification = DefaultMagnification
+	}
+
+	// Resize the image
 	resizedImg := img.Resize(srcImg, inputs.magnification)
 
+	if c.IsSet("threshold") {
+		inputs.threshold = c.Int("threshold")
+	} else {
+		inputs.threshold = asciiArt.CalcOTSUThreshold(resizedImg, resizedImg.Bounds().Dy(), resizedImg.Bounds().Dx())
+	}
+
+	// Generate the ASCII Art
 	output := asciiArt.Generate(resizedImg, inputs.threshold)
 
+	// Print the ASCII Art
 	fmt.Print(output)
 
 	err = img.UnSync(resizedImg)
 	if err != nil {
-		log.Fatalf("Error: %v", err)
+		return err
 	}
+
+	return nil
 }


### PR DESCRIPTION
## issue
- none

## description
- Currently, the default threshold is `128`, but it is not appropriate. Instead, I adopt otsu's method for automatically determine threshold for an each image.

## new behavior
